### PR TITLE
Documentation

### DIFF
--- a/docs/source/appendix.rst
+++ b/docs/source/appendix.rst
@@ -18,7 +18,7 @@ Helpful Links
 
 `HBCD EEG Tasks <https://github.com/ChildDevLab/Tasks>`_ 
 
-`HBCD-MADE pipeline GitHub repository <https://github.com/ChildDevLab/MADE-EEG-preprocessing-pipeline>`_
+`HBCD-MADE pipeline GitHub repository <https://github.com/DCAN-Labs/HBCD-MADE>`_
 
 `Singularity User Guide <https://docs.sylabs.io/guides/latest/user-guide/>`_
 

--- a/docs/source/data_requirements.rst
+++ b/docs/source/data_requirements.rst
@@ -187,7 +187,7 @@ Each HBCD subject/session pair has a corresponding BIDS dataset for that session
 
 1. ``./sub-* folder``
 
-  Stores raw data and metadata. Contains a folder called ``ses-V03`` which houses an ``eeg`` folder and a ``.tsv`` labeled with the subject ID and recording session. This ``.tsv`` contains the file names and date and time of each EEG recording. The eeg folder contains several ``.json``, ``.fdt``, ``.txt`` and ``.edat3`` files in BIDS format providing information about the recording system, location of electrodes, events for each task, and raw data.
+  Stores raw data and metadata. Contains a folder called ``ses-V03`` which houses an ``eeg`` folder and a ``.tsv`` labeled with the subject ID and recording session. This ``.tsv`` contains the file names and date and time of each EEG recording. The eeg folder contains several ``.json``, ``.fdt``, and ``.txt`` files in BIDS format providing information about the recording system, location of electrodes, events for each task, and raw data.
 
 2. ``./dataset_description.json``
 

--- a/docs/source/data_requirements.rst
+++ b/docs/source/data_requirements.rst
@@ -170,7 +170,6 @@ Raw HBCD data folders are curated using the `EEG2BIDS Wizard <https://hbcd-docs.
 
 **File Types:** 
 
-- ``EDAT3``- Contain task-specific event information from E-PRIME (stimulus presentation software).
 - ``TXT``- Contain E-PRIME event log output.
 - ``TSV``- Store metadata and other relevant information.
 - ``JSON``- Store metadata and configuration settings in a format that is easy for users to read and edit.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@
 HBCD-MADE- an automated developmental EEG preprocessing pipeline 
 ==================================================================
 
-.. image:: https://img.shields.io/badge/Psychophysiology-10.1038%2Fs41592--021--01185--5-purple
+.. image:: https://img.shields.io/badge/DOI-10.1038%2Fs41592--021--01185--5-purple
   :target: https://doi.org/10.1111/psyp.13580
   :alt: Publication DOI
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,10 +12,8 @@
 HBCD-MADE- an automated developmental EEG preprocessing pipeline 
 ==================================================================
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7019701.svg)](https://doi.org/10.5281/zenodo.7019701)
-
-.. image:: https://img.shields.io/badge/Nature%20Methods-10.1038%2Fs41592--021--01185--5-purple
-  :target: https://doi.org/10.1038/s41592-021-01185-5
+.. image:: https://img.shields.io/badge/Psychophysiology-10.1038%2Fs41592--021--01185--5-purple
+  :target: https://doi.org/10.1111/psyp.13580
   :alt: Publication DOI
 
 .. image:: https://img.shields.io/badge/License-BSD--3--Clause-green

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,11 +68,11 @@ Contributors
 
 **Original Contributors to MADE pipeline:**
 
-- Ranjan Debnath (rdebnath@umd.edu)
-- George A. Buzzell (gbuzzell@umd.edu)
-- Santiago Morales Pamplona (moraless@umd.edu)
-- Stephanie Leach (sleach12@umd.edu)
-- Maureen Elizabeth Bowers (mbowers1@umd.edu)
+- Ranjan Debnath (ranjan.ju@gmail.com)
+- George A. Buzzell (gbuzzell@fiu.edu)
+- Santiago Morales (santiago.morales@usc.edu)
+- Stephanie Leach (stephanie-leach@uiowa.edu)
+- Maureen Elizabeth Bowers (maureenbowers@gmail.com)
 - Nathan A. Fox (fox@umd.edu)
 
 **Past Contributors:** 
@@ -88,7 +88,7 @@ Contributors
 - Marco McSweeney (mmcsw1@umd.edu)
 - Savannah McNair (smcnair1@umd.edu)
 - Trisha Maheshwari (tmahesh@umd.edu)
-- Whitney Kasenetz (kasenetz@umd.edu)
+- Whitney E. Kasenetz (kasenetz@umd.edu)
 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,8 +16,8 @@ HBCD-MADE- an automated developmental EEG preprocessing pipeline
   :target: https://doi.org/10.1111/psyp.13580
   :alt: Publication DOI
 
-.. image:: https://img.shields.io/badge/License-BSD--3--Clause-green
-  :target: https://opensource.org/licenses/BSD-3-Clause
+.. image:: https://img.shields.io/badge/License-GNU--Public--License-green
+  :target: https://github.com/ChildDevLab/HBCD-MADE?tab=GPL-3.0-1-ov-file#readme
   :alt: License
 
 DOI: `10.1111/psyp.13580 <https://onlinelibrary.wiley.com/doi/10.1111/psyp.13580>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,10 +9,18 @@
 
 .. _citation:
 
-HBCD-MADE Introduction
-======================
+HBCD-MADE- an automated developmental EEG preprocessing pipeline 
+==================================================================
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7019701.svg)](https://doi.org/10.5281/zenodo.7019701)
+
+.. image:: https://img.shields.io/badge/Nature%20Methods-10.1038%2Fs41592--021--01185--5-purple
+  :target: https://doi.org/10.1038/s41592-021-01185-5
+  :alt: Publication DOI
+
+.. image:: https://img.shields.io/badge/License-BSD--3--Clause-green
+  :target: https://opensource.org/licenses/BSD-3-Clause
+  :alt: License
 
 DOI: `10.1111/psyp.13580 <https://onlinelibrary.wiley.com/doi/10.1111/psyp.13580>`_.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,12 +12,6 @@
 HBCD-MADE- an automated developmental EEG preprocessing pipeline 
 ==================================================================
 
-https://zenodo.org/records/14194453
-
-.. image:: https://img.shields.io/badge/DOI-10.1038%2Fs41592--021--01185--5-purple
-  :target: https://doi.org/10.1111/psyp.13580
-  :alt: Publication DOI
-
 .. image:: https://img.shields.io/badge/DOI-10.5281/zenodo.14194452--5-purple
   :target: https://doi.org/10.5281/zenodo.14194452
   :alt: Publication DOI

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,8 +20,6 @@ HBCD-MADE- an automated developmental EEG preprocessing pipeline
   :target: https://github.com/ChildDevLab/HBCD-MADE?tab=GPL-3.0-1-ov-file#readme
   :alt: License
 
-DOI: `10.1111/psyp.13580 <https://onlinelibrary.wiley.com/doi/10.1111/psyp.13580>`_.
-
 This page serves as documentation for the HBCD-MADE pipeline, an adapted version of the Maryland Analysis of Developmental EEG (MADE) pipeline (Debnath et al., 2020) designed for use with data from the Healthy Brain and Child Development (HBCD) study. The GitHub repository for the MADE pipeline upon which HBCD-MADE is based can be found `here <https://github.com/ChildDevLab/MADE-EEG-preprocessing-pipeline>`_, and a publication describing the original pipeline can be found `here <https://onlinelibrary.wiley.com/doi/full/10.1111/psyp.13580>`_. The documentation for the HBCD-MADE pipeline can be found `here <https://docs-hbcd-made.readthedocs.io/en/latest/index.html>`_. 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,15 +12,21 @@
 HBCD-MADE- an automated developmental EEG preprocessing pipeline 
 ==================================================================
 
+https://zenodo.org/records/14194453
+
 .. image:: https://img.shields.io/badge/DOI-10.1038%2Fs41592--021--01185--5-purple
   :target: https://doi.org/10.1111/psyp.13580
+  :alt: Publication DOI
+
+.. image:: https://img.shields.io/badge/DOI-10.5281/zenodo.14194452--5-purple
+  :target: https://doi.org/10.5281/zenodo.14194452
   :alt: Publication DOI
 
 .. image:: https://img.shields.io/badge/License-GNU--Public--License-green
   :target: https://github.com/ChildDevLab/HBCD-MADE?tab=GPL-3.0-1-ov-file#readme
   :alt: License
 
-This page serves as documentation for the HBCD-MADE pipeline, an adapted version of the Maryland Analysis of Developmental EEG (MADE) pipeline (Debnath et al., 2020) designed for use with data from the Healthy Brain and Child Development (HBCD) study. The GitHub repository for the MADE pipeline upon which HBCD-MADE is based can be found `here <https://github.com/ChildDevLab/MADE-EEG-preprocessing-pipeline>`_, and a publication describing the original pipeline can be found `here <https://onlinelibrary.wiley.com/doi/full/10.1111/psyp.13580>`_. The documentation for the HBCD-MADE pipeline can be found `here <https://docs-hbcd-made.readthedocs.io/en/latest/index.html>`_. 
+This page serves as documentation for the HBCD-MADE pipeline, an adapted version of the Maryland Analysis of Developmental EEG (MADE) pipeline (Debnath et al., 2020) designed for use with data from the Healthy Brain and Child Development (HBCD) study. The GitHub repository for the MADE pipeline upon which HBCD-MADE is based can be found `here <https://github.com/DCAN-Labs/HBCD-MADE>`_, and a publication describing the original pipeline can be found `here <https://onlinelibrary.wiley.com/doi/full/10.1111/psyp.13580>`_. The documentation for the HBCD-MADE pipeline can be found `here <https://docs-hbcd-made.readthedocs.io/en/latest/index.html>`_. 
 
 
 The HBCD-MADE pipeline will run preprocessing on BIDS-formatted data with most EEG files being the .set file format. All metadata required for running the HBCD-MADE pipeline is present within the .set files themselves, and other BIDS metadata will not be referenced during processing. In general, HBCD-MADE's functionality is roughly as follows:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,8 @@
 HBCD-MADE Introduction
 ======================
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7019701.svg)](https://doi.org/10.5281/zenodo.7019701)
+
 DOI: `10.1111/psyp.13580 <https://onlinelibrary.wiley.com/doi/10.1111/psyp.13580>`_.
 
 This page serves as documentation for the HBCD-MADE pipeline, an adapted version of the Maryland Analysis of Developmental EEG (MADE) pipeline (Debnath et al., 2020) designed for use with data from the Healthy Brain and Child Development (HBCD) study. The GitHub repository for the MADE pipeline upon which HBCD-MADE is based can be found `here <https://github.com/ChildDevLab/MADE-EEG-preprocessing-pipeline>`_, and a publication describing the original pipeline can be found `here <https://onlinelibrary.wiley.com/doi/full/10.1111/psyp.13580>`_. The documentation for the HBCD-MADE pipeline can be found `here <https://docs-hbcd-made.readthedocs.io/en/latest/index.html>`_. 

--- a/docs/source/proc_settings.json
+++ b/docs/source/proc_settings.json
@@ -73,7 +73,7 @@
       "E127",
       "E128"
     ],
-    "channel_locations": "C:/Users/kasenetz/Documents/HBCD-MADE/0_2AverageNet128_v1.sfp",
+    "channel_locations": "C:/Users/kiral/Documents/UMD/HBCD/HBCD-MADE-CDL_main/0_2AverageNet128_v1.sfp",
     "down_sample": 0,
     "sampling_rate": 1000,
     "delete_outerlayer": 1,
@@ -126,7 +126,7 @@
     "reref": [],
     "output_format": 1
   },
-  "RS": {
+    "RS": {
     "ROI_of_interest": "oz", 
     "make_dummy_events": true,
     "remove_baseline": 0,
@@ -152,7 +152,9 @@
     "marker_names": [
       "DIN3"
     ],
-    "score_times":[[40, 79], [80,140], [141, 300]],
+    "score_ages": [[3,6],[6,9]],
+    "score_times1":[[40, 79], [80,140], [141, 300]],
+    "score_times2":[[40, 79], [80,120], [121, 170]],
     "score_ROIs": ["oz", "oz", "oz"]
 
 
@@ -168,6 +170,7 @@
     "marker_names": [
       "DIN2"
     ],
+    "score_ages": [],
     "score_times":[[200, 400], [200, 400], [200, 400]],
     "score_ROIs": ["t7t8", "f7f8", "fcz"]
   },
@@ -183,7 +186,9 @@
     "marker_names": [
       "DIN3"
     ],
-    "score_times":[[200, 300], [75,125], [200, 300], [325, 625]],
+    "score_ages": [[3,6],[6,9]],
+    "score_times1": [[200, 300], [75,125], [200, 300], [325, 625]],
+    "score_times2": [[250, 350], [100,200], [250, 350], [350, 650]],
     "score_ROIs": ["p8", "oz", "oz", "oz"]
   }
 }


### PR DESCRIPTION
changes to ReadTheDocs- update license, DOI, and switch URLs to link to this repo instead of ChildDevLab's MADE repo